### PR TITLE
Add support for haz & update to syn 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "degeneric-macros"
 authors = ["Tomas Jasek <tomsik68@posteo.net>"]
 description = "Hides struct generics into trait associated types"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2018"
 license = "MIT"
 keywords = ["dependency-injection", "generics", "injection", "di"]
@@ -27,3 +27,4 @@ trait-set = "0.3.0"
 typed-builder = "0.13.0"
 galemu = "0.2.3"
 dynamize = "0.3.5"
+haz = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "degeneric-macros"
 authors = ["Tomas Jasek <tomsik68@posteo.net>"]
 description = "Hides struct generics into trait associated types"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2018"
 license = "MIT"
 keywords = ["dependency-injection", "generics", "injection", "di"]
@@ -16,15 +16,15 @@ proc-macro = true
 path = "src/lib.rs"
 
 [dependencies]
-syn = { version = "1", features = ["full"] }
+syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
-darling = "0.14.1"
+darling = "0.20"
 proc-macro-error = "1"
 
 [dev-dependencies]
 trait-set = "0.3.0"
-typed-builder = "0.13.0"
+typed-builder = "0.14.0"
 galemu = "0.2.3"
 dynamize = "0.3.5"
 haz = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -230,9 +230,11 @@ Degeneric supports dynamizing the generated trait. How does that work?
 Here's a minimal example on how to dynamize the generated trait:
 
 ```rust
+use degeneric_macros::Degeneric;
+
 #[derive(Degeneric)]
 #[degeneric(dynamize, trait = "pub trait GeneratedContainerTrait")]
-struct Container<T: Any> {
+struct Container<T: std::any::Any> {
     item: T,
 }
 ```
@@ -240,6 +242,29 @@ struct Container<T: Any> {
 By convention, dynamize generates a `DynGeneratedContainerTrait` where the types are boxed.
 Please refer to [dynamize documentation](https://docs.rs/dynamize/latest/dynamize/#dynamize)
 for more information.
+
+### Degeneric + haz
+
+Degeneric is able to serve as a derive macro for the excellent
+[`haz`](https://crates.io/crates/haz) crate.
+
+```rust
+use degeneric_macros::Degeneric;
+use haz::Has;
+
+
+ #[derive(Degeneric, Default)]
+ #[degeneric(haz)]
+ struct Config {
+   host: Host,
+   port: Port,
+   verbosity: Verbosity,
+   restriction: Restriction,
+ }
+
+ fn assert_has_all_the_things<T: Has<Host> + Has<Port> + Has<Verbosity> + Has<Restriction>>(_: T) {}
+ assert_has_all_the_things(Config::default());
+```
 
 ## Degeneric understands where clause
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ use typed_builder::TypedBuilder;
 trait_set!(trait FactoryFn<T> = 'static + Send + Sync + Fn() -> T);
 
 #[derive(Degeneric, TypedBuilder)]
-#[degeneric(trait = "pub trait ContainerTrait")]
+#[degeneric(trait_decl = "pub trait ContainerTrait")]
 /// This is doc for ContainerTrait!
 struct Container<T: Default, A: FactoryFn<T>, B> {
     a: A,
@@ -76,7 +76,7 @@ this:
 use degeneric_macros::Degeneric;
 
 #[derive(Degeneric)]
-#[degeneric(trait = "pub trait ContainerTrait")]
+#[degeneric(trait_decl = "pub trait ContainerTrait")]
 struct Container<Logger, HttpClient> {
     logger: Logger,
     client: HttpClient,
@@ -106,7 +106,7 @@ use degeneric_macros::{Degeneric};
 use typed_builder::TypedBuilder;
 
 #[derive(Degeneric, TypedBuilder)]
-#[degeneric(trait = "trait ContainerTrait")]
+#[degeneric(trait_decl = "trait ContainerTrait")]
 struct Container<'a, T: 'a + PartialEq<i32> + Debug> {
     cow: &'a Cow<'a, str>,
     reference: &'a T,
@@ -203,7 +203,7 @@ impl GTran for TransWrap {
 // end galemu
 
 #[derive(Degeneric)]
-#[degeneric(trait = "pub trait ContainerTrait")]
+#[degeneric(trait_decl = "pub trait ContainerTrait")]
 struct Container<T: GCon> {
     conn: T,
 }
@@ -233,7 +233,7 @@ Here's a minimal example on how to dynamize the generated trait:
 use degeneric_macros::Degeneric;
 
 #[derive(Degeneric)]
-#[degeneric(dynamize, trait = "pub trait GeneratedContainerTrait")]
+#[degeneric(dynamize, trait_decl = "pub trait GeneratedContainerTrait")]
 struct Container<T: std::any::Any> {
     item: T,
 }
@@ -273,7 +273,7 @@ use degeneric_macros::{Degeneric};
 use std::fmt::Debug;
 
 #[derive(Degeneric)]
-#[degeneric(trait = "pub trait ContainerTrait")]
+#[degeneric(trait_decl = "pub trait ContainerTrait")]
 struct Container<T> where T: Default + Debug + PartialEq {
     item: T,
 }
@@ -300,7 +300,7 @@ The `no_getter` attribute can be used to skip generating a getter.
 use degeneric_macros::{Degeneric};
 
 #[derive(Degeneric)]
-#[degeneric(trait = "pub(crate) trait Something")]
+#[degeneric(trait_decl = "pub(crate) trait Something")]
 struct Container<'a, T: 'a, S: 'a> {
     item: &'a T,
     item2: S,
@@ -330,7 +330,7 @@ references and skips generating mutable getter for them.
 ```rust
 use degeneric_macros::{Degeneric};
 #[derive(Degeneric)]
-#[degeneric(trait = "pub(crate) trait Something")]
+#[degeneric(trait_decl = "pub(crate) trait Something")]
 struct Container<'a, T: 'a> {
     x: &'a T,
     y: T,
@@ -355,7 +355,7 @@ accept_container(c);
 use degeneric_macros::{Degeneric};
 
 #[derive(Degeneric)]
-#[degeneric(trait = "pub(crate) trait Something")]
+#[degeneric(trait_decl = "pub(crate) trait Something")]
 struct Container<'a, T> {
     x: &'a T,
 }
@@ -390,7 +390,7 @@ If you need more granularity, you can add attributes only on:
 use degeneric_macros::Degeneric;
 
 #[derive(Degeneric)]
-#[degeneric(trait = "pub(crate) trait Something")]
+#[degeneric(trait_decl = "pub(crate) trait Something")]
 #[degeneric(trait_decl_impl_attr = "#[cfg(foo)]")]
 /// This is documentation for the `Something` trait
 struct Container<T> {

--- a/src/degeneric/entrypoint.rs
+++ b/src/degeneric/entrypoint.rs
@@ -22,7 +22,6 @@ struct Degeneric {
     ident: Ident,
     generics: Generics,
 
-    #[darling(rename = "trait")]
     trait_decl: Option<TraitDecl>,
 
     attrs: Vec<Attribute>,

--- a/src/degeneric/entrypoint.rs
+++ b/src/degeneric/entrypoint.rs
@@ -13,8 +13,11 @@ use super::field::*;
 use super::generics::*;
 
 #[derive(FromDeriveInput)]
-#[darling(attributes(degeneric), supports(struct_named))]
-#[darling(attributes(degeneric), forward_attrs(allow, cfg, cfg_attr, doc))]
+#[darling(
+    attributes(degeneric),
+    supports(struct_named),
+    forward_attrs(allow, cfg, cfg_attr, doc)
+)]
 struct Degeneric {
     ident: Ident,
     generics: Generics,

--- a/src/degeneric/field.rs
+++ b/src/degeneric/field.rs
@@ -43,7 +43,7 @@ impl FieldDecl {
             "unable to turn the type into a reference: {err}"
         );
 
-        TraitItem::Method(syn::parse_quote! {
+        TraitItem::Fn(syn::parse_quote! {
             #( #attrs )*
             #( #docs )*
             fn #name (&self) -> #return_type;
@@ -63,7 +63,7 @@ impl FieldDecl {
             "unable to turn the type into a reference: {err}"
         );
 
-        TraitItem::Method(syn::parse_quote! {
+        TraitItem::Fn(syn::parse_quote! {
             #( #attrs )*
             #( #docs )*
             fn #name (&self) -> #return_type {
@@ -85,7 +85,7 @@ impl FieldDecl {
             "unable to turn the type into a reference: {err}"
         );
 
-        TraitItem::Method(syn::parse_quote! {
+        TraitItem::Fn(syn::parse_quote! {
             #( #attrs )*
             #( #docs )*
             fn #name (&mut self) -> #return_type;
@@ -106,7 +106,7 @@ impl FieldDecl {
             "unable to turn the type into a reference: {err}"
         );
 
-        TraitItem::Method(syn::parse_quote! {
+        TraitItem::Fn(syn::parse_quote! {
             #( #attrs )*
             #( #docs )*
             fn #name (&mut self) -> #return_type {

--- a/src/degeneric/type_tools/associated.rs
+++ b/src/degeneric/type_tools/associated.rs
@@ -189,7 +189,7 @@ fn path_to_associated_ty(path: Path, generic_idents: &[&Ident]) -> Path {
     if path.segments.len() == 1 {
         let first_segment = path.segments.first().unwrap();
         if generic_idents.iter().any(|id| **id == first_segment.ident) {
-            let mut segments = Punctuated::<PathSegment, syn::token::Colon2>::new();
+            let mut segments = Punctuated::<PathSegment, syn::Token![::]>::new();
             segments.push(PathSegment {
                 ident: format_ident!("Self"),
                 arguments: PathArguments::None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! trait_set!(trait FactoryFn<T> = 'static + Send + Sync + Fn() -> T);
 //!
 //! #[derive(Degeneric, TypedBuilder)]
-//! #[degeneric(trait = "pub trait ContainerTrait")]
+//! #[degeneric(trait_decl = "pub trait ContainerTrait")]
 //! /// This is doc for ContainerTrait!
 //! struct Container<T: Default, A: FactoryFn<T>, B> {
 //!     a: A,
@@ -74,7 +74,7 @@
 //! use degeneric_macros::Degeneric;
 //!
 //! #[derive(Degeneric)]
-//! #[degeneric(trait = "pub trait ContainerTrait")]
+//! #[degeneric(trait_decl = "pub trait ContainerTrait")]
 //! struct Container<Logger, HttpClient> {
 //!     logger: Logger,
 //!     client: HttpClient,
@@ -104,7 +104,7 @@
 //! use typed_builder::TypedBuilder;
 //!
 //! #[derive(Degeneric, TypedBuilder)]
-//! #[degeneric(trait = "trait ContainerTrait")]
+//! #[degeneric(trait_decl = "trait ContainerTrait")]
 //! struct Container<'a, T: 'a + PartialEq<i32> + Debug> {
 //!     cow: &'a Cow<'a, str>,
 //!     reference: &'a T,
@@ -201,7 +201,7 @@
 //! // end galemu
 //!
 //! #[derive(Degeneric)]
-//! #[degeneric(trait = "pub trait ContainerTrait")]
+//! #[degeneric(trait_decl = "pub trait ContainerTrait")]
 //! struct Container<T: GCon> {
 //!     conn: T,
 //! }
@@ -231,7 +231,7 @@
 //! use degeneric_macros::Degeneric;
 //!
 //! #[derive(Degeneric)]
-//! #[degeneric(dynamize, trait = "pub trait GeneratedContainerTrait")]
+//! #[degeneric(dynamize, trait_decl = "pub trait GeneratedContainerTrait")]
 //! struct Container<T: std::any::Any> {
 //!     item: T,
 //! }
@@ -279,7 +279,7 @@
 //! use std::fmt::Debug;
 //!
 //! #[derive(Degeneric)]
-//! #[degeneric(trait = "pub trait ContainerTrait")]
+//! #[degeneric(trait_decl = "pub trait ContainerTrait")]
 //! struct Container<T> where T: Default + Debug + PartialEq {
 //!     item: T,
 //! }
@@ -306,7 +306,7 @@
 //! use degeneric_macros::{Degeneric};
 //!
 //! #[derive(Degeneric)]
-//! #[degeneric(trait = "pub(crate) trait Something")]
+//! #[degeneric(trait_decl = "pub(crate) trait Something")]
 //! struct Container<'a, T: 'a, S: 'a> {
 //!     item: &'a T,
 //!     item2: S,
@@ -336,7 +336,7 @@
 //! ```
 //! use degeneric_macros::{Degeneric};
 //! #[derive(Degeneric)]
-//! #[degeneric(trait = "pub(crate) trait Something")]
+//! #[degeneric(trait_decl = "pub(crate) trait Something")]
 //! struct Container<'a, T: 'a> {
 //!     x: &'a T,
 //!     y: T,
@@ -361,7 +361,7 @@
 //! use degeneric_macros::{Degeneric};
 //!
 //! #[derive(Degeneric)]
-//! #[degeneric(trait = "pub(crate) trait Something")]
+//! #[degeneric(trait_decl = "pub(crate) trait Something")]
 //! struct Container<'a, T> {
 //!     x: &'a T,
 //! }
@@ -396,7 +396,7 @@
 //! use degeneric_macros::Degeneric;
 //!
 //! #[derive(Degeneric)]
-//! #[degeneric(trait = "pub(crate) trait Something")]
+//! #[degeneric(trait_decl = "pub(crate) trait Something")]
 //! #[degeneric(trait_decl_impl_attr = "#[cfg(foo)]")]
 //! /// This is documentation for the `Something` trait
 //! struct Container<T> {
@@ -484,7 +484,7 @@ use syn::parse_macro_input;
 /// use std::fmt::Debug;
 ///
 /// #[derive(Degeneric)]
-/// #[degeneric(trait = "trait ContainerTrait")]
+/// #[degeneric(trait_decl = "trait ContainerTrait")]
 /// // attribute for both trait declaration and trait impl
 /// #[degeneric(trait_impl_attr = "#[cfg(not(foo))]")]
 /// /// ContainerTrait contains the implementation of `A` and `B` types.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,37 @@
 //! Please refer to [dynamize documentation](https://docs.rs/dynamize/latest/dynamize/#dynamize)
 //! for more information.
 //!
+//! ## Degeneric + haz
+//!
+//! Degeneric is able to serve as a derive macro for the excellent
+//! [`haz`](https://crates.io/crates/haz) crate.
+//!
+//! ```
+//! use degeneric_macros::Degeneric;
+//! use haz::Has;
+//!
+//! # #[derive(Default)]
+//! # struct Host;
+//! # #[derive(Default)]
+//! # struct Port;
+//! # #[derive(Default)]
+//! # struct Verbosity;
+//! # #[derive(Default)]
+//! # struct Restriction;
+//!
+//!  #[derive(Degeneric, Default)]
+//!  #[degeneric(haz)]
+//!  struct Config {
+//!    host: Host,
+//!    port: Port,
+//!    verbosity: Verbosity,
+//!    restriction: Restriction,
+//!  }
+//!
+//!  fn assert_has_all_the_things<T: Has<Host> + Has<Port> + Has<Verbosity> + Has<Restriction>>(_: T) {}
+//!  assert_has_all_the_things(Config::default());
+//! ```
+//!
 //! # Degeneric understands where clause
 //!
 //! ```


### PR DESCRIPTION
With haz support, the `trait_decl` part becomes optional

With the update to `syn` version 2, the `trait` attribute has been renamed to `trait_decl`.